### PR TITLE
Removed turbopack since it breaks svgr loader.

### DIFF
--- a/next.config.ts
+++ b/next.config.ts
@@ -2,13 +2,19 @@ import type { NextConfig } from 'next'
 
 const nextConfig: NextConfig = {
   /* config options here */
-  turbopack: {
-    rules: {
-      '*.svg': {
-        loaders: ['@svgr/webpack'],
-        as: '*.js',
-      },
-    },
+  webpack(config) {
+    config.module.rules.push({
+      test: /\.svg$/,
+      use: [
+        {
+          loader: '@svgr/webpack',
+          options: {
+            svgo: false,
+          },
+        },
+      ],
+    })
+    return config
   },
 }
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -3063,6 +3063,7 @@
       "resolved": "https://registry.npmjs.org/@svgr/webpack/-/webpack-8.1.0.tgz",
       "integrity": "sha512-LnhVjMWyMQV9ZmeEy26maJk+8HTIbd59cH4F2MJ439k9DqejRisfFNGAPvRYlKETuh9LrImlS8aKsBgKjMA8WA==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "@babel/core": "^7.21.3",
         "@babel/plugin-transform-react-constant-elements": "^7.21.3",
@@ -3388,7 +3389,7 @@
       "version": "19.0.10",
       "resolved": "https://registry.npmjs.org/@types/react/-/react-19.0.10.tgz",
       "integrity": "sha512-JuRQ9KXLEjaUNjTWpzuR231Z2WpIwczOkBEIvbHNCzQefFIT0L8IqE6NV6ULLyC1SI/i234JnDoMkfg+RjQj2g==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "csstype": "^3.0.2"
@@ -3398,7 +3399,7 @@
       "version": "19.0.4",
       "resolved": "https://registry.npmjs.org/@types/react-dom/-/react-dom-19.0.4.tgz",
       "integrity": "sha512-4fSQ8vWFkg+TGhePfUzVmat3eC14TXYSsiiDSLI0dVLsrm9gZFABjPy/Qu6TKgl1tq1Bu1yDsuQgY3A3DOjCcg==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "peerDependencies": {
         "@types/react": "^19.0.0"

--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "version": "0.1.0",
   "private": true,
   "scripts": {
-    "dev": "next dev --turbopack",
+    "dev": "next dev",
     "build": "next build",
     "start": "next start",
     "lint": "next lint"

--- a/src/app/about/sections/Values.tsx
+++ b/src/app/about/sections/Values.tsx
@@ -4,6 +4,7 @@ import CommunityIcon from '@/shared/assets/icons/community.svg'
 import ExplorationIcon from '@/shared/assets/icons/exploration.svg'
 import OpenMindedIcon from '@/shared/assets/icons/openminded.svg'
 import Container from '@/shared/components/layout/Container'
+
 const values = [
   {
     title: 'Exploration',
@@ -45,7 +46,7 @@ const Values = () => {
           {values.map(({ title, icon: Icon, description }) => (
             <div key={title} className="flex flex-col gap-4 rounded-xl p-6 shadow-xl">
               <div className="flex items-center gap-2">
-                <Icon className="h-12 w-12" arial-hidden="true" />
+                <Icon className="h-12 w-12" aria-hidden="true" />
                 <h4 className="text-sub1">{title}</h4>
               </div>
               <div className="text-body3 text-gray-600">{description}</div>


### PR DESCRIPTION
## 📝 Description
Removed turbopack so that svgr can build in a prod env.

---
## 🧪 Testing
Run npm run build

---

## 📘 Important Notes 
For some reason, on the next.js website it says it supports svgr but it seems outdated and it doesn't support it as a loader. I removed turbopack from dev now as well since we have a small project right now.